### PR TITLE
fix: Fix a typo in index.js of useScroll

### DIFF
--- a/useScroll/index.js
+++ b/useScroll/index.js
@@ -1,1 +1,1 @@
-export { useScroll as default } from "./useSroll";
+export { useScroll as default } from "./useScroll";


### PR DESCRIPTION
Hi,
I noticed that there's a typo in <code>index.js</code> in the <code>useScroll</code> directory.
There's a missing <code>c</code> in <code>"./useSroll"</code>, so I fixed it.
Thanks for reading!